### PR TITLE
Fix memory leak in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ pub fn main() !void {
     
     // 1. Create a profiler by wrapping your allocator
     var zprof = try zprof.Zprof.init(&gpa_allocator, true); // true enables logging
+    defer gpa_allocator.destroy(zprof);
     
     // 2. Use the profiler's allocator instead of your original one
     const allocator = zprof.allocator;

--- a/src/zprof.zig
+++ b/src/zprof.zig
@@ -149,8 +149,9 @@ pub const Zprof = struct {
     /// When true, allocation events can be logged to stdout.
     log: bool,
 
-    /// Initialize a new Zprof instance.
-    /// Wraps an existing allocator with memory profiling capabilities.
+    /// Allocates and initializes a new Zprof instance
+    /// Wraps an existing allocator with memory profiling capabilities. The
+    /// caller is responsible for freeing the profiler with `allocator.destroy`.
     pub fn init(allocator: *std.mem.Allocator, log: bool) !*Self {
         // create our custom allocator with profiling hooks
         const zprof_ptr = try allocator.create(Zprof);


### PR DESCRIPTION
The `init` method (maybe should be named `create`?) allocates space for the profiler using the given `allocator` that's being wrapped by the profiler. This means callers need to free it with destroy to avoid leaking memory