### PR TITLE
Add test for memory leak detection and fix hasLeaks

### DIFF
--- a/src/zprof.zig
+++ b/src/zprof.zig
@@ -71,8 +71,8 @@ pub const Profiler = struct {
     /// Check if has memory leaks.
     /// Returns true if any allocations weren't properly freed.
     pub inline fn hasLeaks(self: *Self) bool {
-        // if counts don't match or there's still memory around, we have leaks
-        return (self.alloc_count != self.free_count) or (self.live_bytes > 0);
+        // Counts not matching doesn't necessarily mean memory is leaked because of remap and resize
+        return self.live_bytes > 0;
     }
 
     /// Resets all profiling statistics.

--- a/src/zprof.zig
+++ b/src/zprof.zig
@@ -269,16 +269,21 @@ test "live_bytes" {
     try std.testing.expectEqual(0, zprof.profiler.live_bytes);
 
     const data_a = try allocator.alloc(u8, 1024);
-    errdefer allocator.free(data_a);
-    try std.testing.expectEqual(1024, zprof.profiler.live_bytes);
-
+    {
+        errdefer allocator.free(data_a);
+        try std.testing.expectEqual(1024, zprof.profiler.live_bytes);
+    }
     const data_b = try allocator.create(struct { name: [8]u8 });
-    errdefer allocator.destroy(data_b);
-    try std.testing.expectEqual(1032, zprof.profiler.live_bytes);
-
-    allocator.free(data_a);
-    try std.testing.expectEqual(8, zprof.profiler.live_bytes);
-
+    {
+        errdefer allocator.free(data_a);
+        errdefer allocator.destroy(data_b);
+        try std.testing.expectEqual(1032, zprof.profiler.live_bytes);
+    }
+    {
+        errdefer allocator.destroy(data_b);
+        allocator.free(data_a);
+        try std.testing.expectEqual(8, zprof.profiler.live_bytes);
+    }
     allocator.destroy(data_b);
     try std.testing.expectEqual(0, zprof.profiler.live_bytes);
 

--- a/src/zprof.zig
+++ b/src/zprof.zig
@@ -59,7 +59,9 @@ pub const Profiler = struct {
     /// Updates profiler simulating free.
     /// Called internally whenever memory is freed.
     inline fn updateFree(self: *Self, size: u64) void {
-        // decrease live bytes and increment free counter
+        // Decrease live bytes and increment free counter
+        // This can underflow in the case of invalid frees
+        // Don't know if that's a problem
         self.live_bytes -= size;
         self.free_count += 1;
 


### PR DESCRIPTION
Zprof counts a size decrease as a free and a size increase as an allocation in the case of remap and resize.
This can lead to free_count and alloc_count not being equal even though all memory is freed.
Also fixed double free when live_bytes test fails in the wrong place. (I know the fix is ugly)