### PR TITLE
Change logging and update build.zig to work with zig version 0.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,28 +71,33 @@ Here's how to use `Zprof` in three easy steps:
 
 ```zig
 const std = @import("std");
-const Zprof = @import("zprof").Zprof;
+const Zprof = @import("zprof.zig").Zprof;
 
 pub fn main() !void {
+    var stdout_buf: [4096]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buf);
+    const stdout = &stdout_writer.interface;
+    defer stdout.flush() catch {};
+
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     var gpa_allocator = gpa.allocator();
-    
+
     // 1. Create a profiler by wrapping your allocator
-    var zprof = try Zprof(false).init(&gpa_allocator, true);
-    // false disable thread-safe mode and true enables logging
+    var zprof = try Zprof(false).init(&gpa_allocator, stdout);
+    // false disable thread-safe mode and passing in a writer enables logging
 
     defer zprof.deinit(); // deallocates Zprof instance
-    
+
     // 2. Use the profiler's allocator instead of your original one
     const allocator = zprof.allocator;
-    
+
     // 3. Use the allocator as normal
     const data = try allocator.alloc(u8, 1024);
     defer allocator.free(data);
-    
+
     // Check for leaks
-    std.debug.print("Has leaks: {}\n", .{zprof.profiler.hasLeaks()});
+    stdout.print("Has leaks: {}\n", .{zprof.profiler.hasLeaks()}) catch {};
 }
 ```
 
@@ -103,7 +108,7 @@ pub fn main() !void {
 To start profiling memory usage, simply wrap your allocator with `Zprof`:
 
 ```zig
-var zprof = try Zprof(false).init(&allocator, false); // on init, false disables automatic logging
+var zprof = try Zprof(false).init(&allocator, null); // on init, null disables automatic logging
 const tracked_allocator = zprof.allocator;
 ```
 
@@ -112,7 +117,7 @@ const tracked_allocator = zprof.allocator;
 To use `Zprof` with mutex, you must enable thread-safe mode:
 
 ```zig
-var zprof = try Zprof(true).init(&allocator, false); // true enables thread-safe mode
+var zprof = try Zprof(true).init(&allocator, null); // true enables thread-safe mode
 const tracked_allocator = zprof.allocator;
 ```
 
@@ -122,7 +127,7 @@ If logging is enabled, logs allocated/deallocated bytes when allocator
 allocates or deallocates.
 
 ```zig
-var zprof = try Zprof(false).init(&allocator, true); // true enables automatic logging
+var zprof = try Zprof(false).init(&allocator, arraylist_writer); // Passing in a writer enables automatic logging
 const tracked_allocator = zprof.allocator;
 
 const data = try allocator.alloc(u8, 1024); // prints: Zprof::ALLOC allocated=1024
@@ -174,7 +179,7 @@ test "no memory leaks" {
     defer arena.deinit();
     var arena_allocator = arena.allocator();
     
-    var zprof = try Zprof(false).init(&arena_allocator, false);
+    var zprof = try Zprof(false).init(&arena_allocator, null);
     defer zprof.deinit();
 
     const allocator = zprof.allocator;

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ const zprof_dep = b.dependency("zprof", .{
 exe.root_module.addImport("zprof", zprof_dep.module("zprof"));
 ```
 
-Else can you you put `zprof.zig` in yours project path and import it.
+Else you can put `zprof.zig` in your project's path and import it.
+
+Zig version 0.15.1 or newer is required to compile Zprof
 
 ## 🚀 Quick Start
 

--- a/build.zig
+++ b/build.zig
@@ -16,9 +16,10 @@ pub fn build(b: *std.Build) void {
     });
 
     // Create the static library
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "zprof",
         .root_module = module,
+        .linkage = .static,
     });
 
     // This declares intent for the library to be installed into the standard location

--- a/src/zprof.zig
+++ b/src/zprof.zig
@@ -260,7 +260,7 @@ inline fn diff(a: usize, b: usize) ?usize {
 
 test "live bytes" {
     var test_allocator = std.testing.allocator;
-    var zprof = try Zprof(false).init(&test_allocator, false);
+    var zprof = try Zprof(false).init(&test_allocator, null);
     defer zprof.deinit();
 
     const allocator = zprof.allocator;
@@ -285,7 +285,7 @@ test "live bytes" {
 
 test "memory leak" {
     var test_allocator = std.testing.allocator;
-    var zprof = try Zprof(false).init(&test_allocator, false);
+    var zprof = try Zprof(false).init(&test_allocator, null);
     defer zprof.deinit();
 
     const allocator = zprof.allocator;


### PR DESCRIPTION
It bothered me that zprof is using std.debug.print() and thought it would be cool to allow the user to pass in there own writer.
This allows the user to choose where and how the logs are written. For example having the logs be written to an arraylist.
This change does mean that to compile and use the project a zig version of at least 0.15.1 (newest stable) is required.
I have compiled and tested with zig version 0.15.1 (ran the tests and examples)